### PR TITLE
feat(mqtt/ui) Add more error handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-connio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Node-RED nodes for Connio",
   "repository": "git@github.com:connio/node-red-contrib-connio.git",
   "author": "Connio Inc.",

--- a/src/mqtt/ui/mqtt.js
+++ b/src/mqtt/ui/mqtt.js
@@ -448,13 +448,23 @@
 
         syncValue($clientId, 'clientId', '');
         syncValue($app, 'app', '');
-        syncValue($account, 'account', '');
 
         syncValue($topicPrefix, 'topicPrefix', topicInstance.buildPrefix());
         syncValue($topicValue, 'topicValue', topicInstance.buildValue());
 
+        syncValue($account, 'account', '');
         syncValue($apiKeyId, 'apiKeyId', '');
         syncValue($apiKeySecret, 'apiKeySecret', '');
+
+        $clientId
+          .prop(...PropertyState.Disabled)
+          .empty()
+          .append(makeDefaultOption(this._('api-client-field.placeholder')));
+
+        $app
+          .prop(...PropertyState.Disabled)
+          .empty()
+          .append(makeDefaultOption(this._('app-field.placeholder')));
       };
 
       /**

--- a/src/mqtt/ui/mqtt.js
+++ b/src/mqtt/ui/mqtt.js
@@ -540,7 +540,6 @@
             $auth.prop(...PropertyState.Enabled);
           })
           .finally(() => {
-            $topicValue.prop(...PropertyState.Enabled);
           });
       };
 


### PR DESCRIPTION
- Handle unsuccessful request
- Handle unsuccessful authorization
- Reset "ClientId" and "App" selectors on "new connio-credentials" selection
- Don’t enable "topicValue" field if authorization is unsuccessful