### PR TITLE
fix(mqtt/ui) Invalid API Client’s empty message translation key

### DIFF
--- a/src/mqtt/ui/mqtt.js
+++ b/src/mqtt/ui/mqtt.js
@@ -364,7 +364,7 @@
             .empty()
             .append(
               makeDefaultOption(
-                this._('api-field.empty', {
+                this._('api-client-field.empty', {
                   entity: this._('glossary.api-client'),
                 }),
               ),


### PR DESCRIPTION
Issue #63